### PR TITLE
Feature/make cache key use rule hash

### DIFF
--- a/src/Filter.php
+++ b/src/Filter.php
@@ -129,11 +129,7 @@ abstract class Filter
     public function generateCacheKey(Request $request)
     {
         // NOTE: $request is an unused variable here, but needed in a class that extends this one
-        return $this->client->device->family .
-               ':' .
-               $this->client->ua->family .
-               ':' .
-               $this->client->ua->toVersion();
+        return $this->client->device->family . ':' . $this->client->ua->family . ':' . $this->client->ua->toVersion();
     }
 
     /**
@@ -236,7 +232,8 @@ abstract class Filter
         }
 
         if ($redirect) {
-            $request->session()->flash('redirected', true);
+            $request->session()
+                    ->flash('redirected', true);
 
             return $this->redirector->route($redirect);
         }
@@ -347,7 +344,8 @@ abstract class Filter
      */
     public function onRedirectPath(Request $request)
     {
-        return $request->session()->get('redirected', false);
+        return $request->session()
+                       ->get('redirected', false);
     }
 
     /**

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -126,7 +126,15 @@ abstract class Filter
      *
      * @return string
      */
-    abstract public function generateCacheKey(Request $request);
+    public function generateCacheKey(Request $request)
+    {
+        // NOTE: $request is an unused variable here, but needed in a class that extends this one
+        return $this->client->device->family .
+               ':' .
+               $this->client->ua->family .
+               ':' .
+               $this->client->ua->toVersion();
+    }
 
     /**
      * Get the browsers being filtered.

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -126,11 +126,7 @@ abstract class Filter
      *
      * @return string
      */
-    public function generateCacheKey(Request $request)
-    {
-        // NOTE: $request is an unused variable here, but needed in a class that extends this one
-        return $this->client->device->family . ':' . $this->client->ua->family . ':' . $this->client->ua->toVersion();
-    }
+    abstract public function generateCacheKey(Request $request);
 
     /**
      * Get the browsers being filtered.

--- a/src/Stack/Filter.php
+++ b/src/Stack/Filter.php
@@ -2,6 +2,7 @@
 
 namespace Spinen\BrowserFilter\Stack;
 
+use Illuminate\Http\Request;
 use Spinen\BrowserFilter\Exceptions\InvalidFilterTypeException;
 use Spinen\BrowserFilter\Filter as CoreFilter;
 
@@ -16,6 +17,23 @@ class Filter extends CoreFilter
      * @inheritDoc
      */
     protected $block_filter = true;
+
+    /**
+     * @inheritDoc
+     */
+    public function generateCacheKey(Request $request)
+    {
+        // NOTE: $request is an unused variable here, but needed in a class that extends this one
+
+        // Append the rules with the version of the browser to allow new rules to bust the cache
+        return md5(json_encode($this->config->get($this->config_path . 'rules', []))) .
+               ':' .
+               $this->client->device->family .
+               ':' .
+               $this->client->ua->family .
+               ':' .
+               $this->client->ua->toVersion();
+    }
 
     /**
      * @inheritDoc

--- a/src/Stack/Filter.php
+++ b/src/Stack/Filter.php
@@ -28,11 +28,7 @@ class Filter extends CoreFilter
         // Append the rules with the version of the browser to allow new rules to bust the cache
         return md5(json_encode($this->config->get($this->config_path . 'rules', []))) .
                ':' .
-               $this->client->device->family .
-               ':' .
-               $this->client->ua->family .
-               ':' .
-               $this->client->ua->toVersion();
+               parent::generateCacheKey($request);
     }
 
     /**

--- a/src/Stack/Filter.php
+++ b/src/Stack/Filter.php
@@ -23,8 +23,6 @@ class Filter extends CoreFilter
      */
     public function generateCacheKey(Request $request)
     {
-        // NOTE: $request is an unused variable here, but needed in a class that extends this one
-
         // Append the rules with the version of the browser to allow new rules to bust the cache
         return md5(json_encode($this->config->get($this->config_path . 'rules', []))) .
                ':' .

--- a/tests/Stack/FilterTest.php
+++ b/tests/Stack/FilterTest.php
@@ -2,7 +2,6 @@
 
 namespace Spinen\BrowserFilter\Stack;
 
-use Mockery;
 use Spinen\BrowserFilter\FilterCase;
 
 /**
@@ -27,6 +26,27 @@ class FilterTest extends FilterCase
     public function it_can_be_constructed()
     {
         $this->assertInstanceOf(Filter::class, $this->filter);
+    }
+
+    /**
+     * @test
+     */
+    public function it_generates_the_cache_key()
+    {
+        $this->client_device_mock->family = 'Device';
+        $this->client_ua_mock->family = 'Browser';
+
+        $this->client_ua_mock->shouldReceive('toVersion')
+                             ->once()
+                             ->withNoArgs()
+                             ->andReturn('1.2.3');
+
+        $this->config_mock->shouldReceive('get')
+                          ->withArgs(['browserfilter.rules', []])
+                          ->andReturn([]);
+
+        $this->assertEquals(md5(json_encode([])) . ':Device:Browser:1.2.3',
+            $this->filter->generateCacheKey($this->request_mock));
     }
 
     /**


### PR DESCRIPTION
Makes it so that the rules are part of the cache key to let new rules bust the cache.  Identified as a usability issue in #10.  Closes #13.